### PR TITLE
KA-453 Distinguish badges for master and develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-[![Build Status](https://travis-ci.org/Kentico/kentico-cloud-docs-webhooks.svg?branch=master)](https://travis-ci.org/Kentico/kentico-cloud-docs-webhooks)
-[![codebeat badge](https://codebeat.co/badges/dbbf18e6-89db-4046-89d5-fa5920191169)](https://codebeat.co/projects/github-com-kentico-kentico-cloud-docs-webhooks-master)
+| [master](https://github.com/Kentico/kentico-cloud-docs-webhooks/tree/master) | [develop](https://github.com/Kentico/kentico-cloud-docs-webhooks/tree/develop) |
+|:---:|:---:|
+|[![Build Status](https://travis-ci.org/Kentico/kentico-cloud-docs-webhooks.svg?branch=master)](https://travis-ci.org/Kentico/kentico-cloud-docs-webhooks/branches) [![codebeat badge](https://codebeat.co/badges/dbbf18e6-89db-4046-89d5-fa5920191169)](https://codebeat.co/projects/github-com-kentico-kentico-cloud-docs-webhooks-master) | [![Build Status](https://travis-ci.org/Kentico/kentico-cloud-docs-webhooks.svg?branch=develop)](https://travis-ci.org/Kentico/kentico-cloud-docs-webhooks/branches) [![codebeat badge](https://codebeat.co/badges/5444bea6-b966-436d-8738-f7787bf84956)](https://codebeat.co/projects/github-com-kentico-kentico-cloud-docs-webhooks-develop) |
 
 # kentico-cloud-docs-webhooks
 Kentico Cloud documentation - webhooks service


### PR DESCRIPTION
CodeBeat for `develop` branch added and badges for both `master` and `develop` displayed together.